### PR TITLE
Turn off subresource_integrity

### DIFF
--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -311,7 +311,7 @@ module Web
         # Subresource Integrity
         #
         # See: http://hanamirb.org/guides/assets/content-delivery-network/#subresource-integrity
-        subresource_integrity :sha256
+        subresource_integrity false
       end
     end
   end


### PR DESCRIPTION
Now in the crome v 57 we have problems to load css styles.

<img width="1276" alt="screen shot 2017-04-06 at 14 10 02" src="https://cloud.githubusercontent.com/assets/1192122/24746541/e0875a08-1ad2-11e7-978b-f8d127ea3dce.png">

I think we should temporary turn off this settings, because we announce 1.0.0 with link to contributors 
