### PR TITLE
Add commits count to users page

### DIFF
--- a/apps/web/controllers/contributors/show.rb
+++ b/apps/web/controllers/contributors/show.rb
@@ -3,11 +3,14 @@ module Web::Controllers::Contributors
     include Web::Action
     include Hanami::Pagination::Action
 
-    expose :contributor, :commits
+    expose :contributor, :commits, :commits_count
 
     def call(params)
       @contributor = ContributorRepository.new.find_by_github(params[:id])
-      @commits = all_for_page(CommitRepository.new.all_for_contributor(@contributor.id))
+      commits = CommitRepository.new.all_for_contributor(@contributor.id)
+
+      @commits_count = commits.to_a.size
+      @commits = all_for_page(commits)
     end
   end
 end

--- a/apps/web/controllers/contributors/show.rb
+++ b/apps/web/controllers/contributors/show.rb
@@ -9,7 +9,7 @@ module Web::Controllers::Contributors
       @contributor = ContributorRepository.new.find_by_github(params[:id])
       commits = CommitRepository.new.all_for_contributor(@contributor.id)
 
-      @commits_count = commits.to_a.size
+      @commits_count = commits.count
       @commits = all_for_page(commits)
     end
   end

--- a/apps/web/templates/contributors/show.html.slim
+++ b/apps/web/templates/contributors/show.html.slim
@@ -1,5 +1,5 @@
 h3 
-  | All #{contributor.github} commits
+  | All #{contributor.github} commits (#{commits_count})
 
 table.table.table-hover
   - commits.each do |commit|


### PR DESCRIPTION
This pull request adds number of commits integrated into the core for each contributor on its personal page

/cc @cllns 