### PR TITLE
Add admin page to list all available projects in DB

### DIFF
--- a/apps/admin/controllers/projects/index.rb
+++ b/apps/admin/controllers/projects/index.rb
@@ -2,7 +2,10 @@ module Admin::Controllers::Projects
   class Index
     include Admin::Action
 
+    expose :projects
+
     def call(params)
+      @projects = ProjectRepository.new.sorted
     end
   end
 end

--- a/apps/admin/templates/application.html.slim
+++ b/apps/admin/templates/application.html.slim
@@ -4,5 +4,7 @@ html
     title
       | Admin
     = favicon
+    = stylesheet 'bootstrap', 'main'
   body
-    = yield
+    .container
+      = yield

--- a/apps/admin/templates/projects/index.html.slim
+++ b/apps/admin/templates/projects/index.html.slim
@@ -1,1 +1,11 @@
-p Here will be all projects!
+h2 All projects
+
+table.table.table-hover
+  tr
+    th Project name
+    th Since
+  - projects.each do |project|
+    tr
+      td = link_to_github(project)
+      td = project.created_at.strftime('%d %B %Y')
+

--- a/apps/admin/views/projects/index.rb
+++ b/apps/admin/views/projects/index.rb
@@ -1,5 +1,9 @@
 module Admin::Views::Projects
   class Index
     include Admin::View
+
+    def link_to_github(project)
+      link_to project.name, "https://github.com/hanami/#{project.name}"
+    end
   end
 end

--- a/lib/contributors/repositories/project_repository.rb
+++ b/lib/contributors/repositories/project_repository.rb
@@ -1,2 +1,5 @@
 class ProjectRepository < Hanami::Repository
+  def sorted
+    projects.order { name.asc }
+  end
 end

--- a/spec/admin/controllers/projects/index_spec.rb
+++ b/spec/admin/controllers/projects/index_spec.rb
@@ -6,4 +6,34 @@ RSpec.describe Admin::Controllers::Projects::Index, type: :action do
     response = action.call(params)
     expect(response[0]).to eq 200
   end
+
+  describe 'expose' do
+    describe '#projects' do
+      context 'when db empty' do
+        before { action.call(params) }
+
+        it { expect(action.projects.to_a).to eq [] }
+      end
+
+      context 'when db has some projects' do
+        let(:project_repo) { ProjectRepository.new }
+
+        before do
+          project_repo.create(name: 'contributors')
+          action.call(params)
+        end
+
+        after do
+          project_repo.clear
+        end
+
+        it 'returns all projects' do
+          projects = action.projects.to_a
+
+          expect(projects).to all(be_a(Project))
+          expect(projects.count).to eq 1
+        end
+      end
+    end
+  end
 end

--- a/spec/admin/views/projects/index_spec.rb
+++ b/spec/admin/views/projects/index_spec.rb
@@ -3,4 +3,12 @@ RSpec.describe Admin::Views::Projects::Index, type: :view do
   let(:template)  { Hanami::View::Template.new('apps/admin/templates/projects/index.html.slim') }
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
+
+  describe '#link_to_github' do
+    let(:project) { Project.new(name: 'contributors') }
+
+    it 'returns link to project github' do
+      expect(view.link_to_github(project).to_s).to eq '<a href="https://github.com/hanami/contributors">contributors</a>'
+    end
+  end
 end


### PR DESCRIPTION
It is one of the requested feature of #39

This PR adds a page that list all available projects in DB and that is only available to logged in users.

I decided to sort it alphabetically and add bootstrap styling since it was already available.

It looks like this:

<img width="1232" alt="Admin projects listing" src="https://user-images.githubusercontent.com/25862/35994957-3f988c6a-0d12-11e8-9131-19d36a792f09.png">

