### PR TITLE
Add dummy Detail contributor peration for show pag

### DIFF
--- a/lib/contributors/operations/detail.rb
+++ b/lib/contributors/operations/detail.rb
@@ -1,0 +1,12 @@
+require 'hanami/interactor'
+
+module Operations
+  class Detail
+    include Hanami::Interactor
+    expose :contributor
+
+    def call
+      @contributor = nil
+    end
+  end
+end

--- a/spec/contributors/operations/detail_spec.rb
+++ b/spec/contributors/operations/detail_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Operations::Detail do
+  let(:operation) { described_class.new }
+  subject { operation.call }
+
+  it { expect(subject).to be_successful }
+  it { expect(subject.contributor).to eq nil }
+end


### PR DESCRIPTION
I am not sure this is exactly what is requested, but I'm trying to follow the instructions left in issue https://github.com/hanami/contributors/issues/20

I assumed the intent of the first request is to duplicate the current implementation for the `List` operation for contributors and have something similar for the show page. 
If someone could confirm that, I'd be grateful.
